### PR TITLE
Fix email sending from contact form

### DIFF
--- a/server.js
+++ b/server.js
@@ -96,8 +96,9 @@ app.post('/submit', async (req, res) => {
             .request({
                 Messages: [
                     {
-                        // Send the email from the address provided by the user
-                        From: { Email: newContact.email, Name: newContact.name },
+                        // Use a verified sender address; set user's email as reply-to
+                        From: { Email: 'mohamedtahamejdoub@gmail.com', Name: 'Portfolio Contact' },
+                        ReplyTo: { Email: newContact.email, Name: newContact.name },
                         // Always send the message to the portfolio owner's inbox
                         To: [{ Email: 'mohamedtahamejdoub@gmail.com' }],
                         Subject: 'New contact request',


### PR DESCRIPTION
## Summary
- keep `From` address verified when using Mailjet
- set the user's email as ReplyTo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b505ca088326b1aad3ea717675af